### PR TITLE
Adding Snowflake tasks for Generic FMC

### DIFF
--- a/snowflake_tasks/README.md
+++ b/snowflake_tasks/README.md
@@ -1,0 +1,40 @@
+# Prerequisites:
+NOTE: This code package does not yet handle Object-specific loading window. You must use standard batch loading with parameter OBJECT_SPECIFIC_LOADING_WINDOW = N in VaultSpeed.
+
+ - This code package assumes you have setup your VaultSpeed agent and it is able to connect to your Snowflake account and has privileges to run DDL scripts.
+
+ - In your agent environment, install:
+        - SnowSQL (Snowflake SQL API) https://docs.snowflake.com/en/user-guide/snowsql-install-config
+        - jq (JSON tool for command line) https://jqlang.github.io/jq/download/
+
+ - Copy the deployment script, snowsql_deploy.sh, to your agent folder.
+
+ - In the agent's client.properties file, set the path of the deploy.cmd parameter to the path for snowsql_deploy.sh.
+    Example line: 
+        deploy.cmd = sh /home/agent/snowsql_deploy.sh {zipname}
+
+ - Restart the VaultSpeed agent for the new settings to take effect.
+
+ - In the SnowSQL config file (~/.snowsql/config), name the connection and set the connection properties to be used by the SnowSQL API and save it. You can use your preferred authentication method. This example uses USERNAME and PASSWORD authentication:
+        
+        [connections.{your_connection_name}]
+        #Can be used in SnowSql as #connect example
+
+        accountname = {your_account}.{your_region}.{your_cloud}
+        username = {your_username}
+        password = {your_password}
+        warehousename = {your_warehouse}
+        dbname = {your_db}
+
+ - Open the snowsql_deploy.sh shell script, and the change the variable values to reflect the your environments, an save it:
+
+        snowsql_conn= {your_connection_name}
+        snowflake_warehouse= {your_warehouse}
+        task_schema= {your_Snowflake_task_schema}
+        default_schedule= "{your_default_schedule}"
+        agent_folder= {your_agent_folder_path}   
+
+ - In VaultSpeed, set up a Data Vault with FMC_TYPE = Generic and ETL Generation type = Snowflake SQL. Make sure you have generated all the FMC flows created. Be sure to use a valid schedule interval provided in the Snowflake Tasks documentation. Do not enclose the schedule interval value in double quotes (") or single quotes (').
+ 
+# Usage
+After completing the prerequisites, go the Automatic Deployment screen in your VaultSpeed subscription. Select the generic FMC generation you wish to deploy and click the up arrow to deploy it. Select the Custom Script option and click deploy.

--- a/snowflake_tasks/SF_DAG_DEPLOY_OBJECTS.sql
+++ b/snowflake_tasks/SF_DAG_DEPLOY_OBJECTS.sql
@@ -1,0 +1,189 @@
+/*******************************************************************/
+/*  Run this script to create the SQL objects needed for deploying */
+/*  and running a Snowflake DAG of Tasks from VaultSpeed           */
+/*******************************************************************/
+
+-- 1. Create tasks schema
+CREATE OR REPLACE SCHEMA TASKER;
+
+-- 2. Create work table to storing and parsing JSON mapping files
+CREATE OR REPLACE TABLE TASKER.TASK_MAPPING (ID NUMBER(38,0) autoincrement, JSON_MAPPING VARIANT );
+
+-- 3. Create sequence object to generate the load cycle id
+CREATE OR REPLACE SEQUENCE TASKER.FMC_SEQ START = 1 INCREMENT = 1;
+
+-- 4. Create stored procedure to get the load cycle id from the sequence object
+CREATE OR REPLACE PROCEDURE BRYAN.TASKER.GET_LOAD_CYCLE_ID()
+RETURNS VARCHAR(16777216)
+LANGUAGE JAVASCRIPT
+EXECUTE AS OWNER
+AS '
+      var LoadCycleIdRslt=snowflake.execute({ sqlText: " SELECT TASKER.FMC_SEQ.NEXTVAL"});
+      LoadCycleIdRslt.next();
+      var LoadCycleId = LoadCycleIdRslt.getColumnValue(1);
+      var lci_str="''"+LoadCycleId+"''";
+      var sql_str="CALL SYSTEM$SET_RETURN_VALUE("+lci_str+")";
+      var res = snowflake.execute({sqlText:sql_str});
+      return "SUCCESS";
+';
+
+-- 5. Create wrapper stored procedure for running procedures and logging failure if procedure fails
+CREATE OR REPLACE PROCEDURE BRYAN.TASKER.RUN_MAPPING_PROC("PROC_NAME" VARCHAR(50), "LOAD_CYCLE_ID" VARCHAR(16777216))
+RETURNS VARCHAR(16777216)
+LANGUAGE JAVASCRIPT
+EXECUTE AS OWNER
+AS '
+    var call_sp_sql = "CALL "+PROC_NAME;
+    try {
+        snowflake.execute( {sqlText: call_sp_sql} );
+        result = "SUCCESS";
+        }
+    catch (err)  {
+        result =  "Failed: Code: " + err.code + "\\\\n  State: " + err.state;
+        result += "\\\\n  Message: " + err.message;
+        result += "\\\\nStack Trace:\\\\n" + err.stackTraceTxt;
+        }
+    return result;
+';
+
+-- 6. Create procedure to generate Snowflake tasks in a dag
+CREATE OR REPLACE PROCEDURE BRYAN.TASKER.CREATE_VS_FMC("VAR_WH" VARCHAR(255), "TASK_SCHEMA" VARCHAR(255), "DAG_NAME" VARCHAR(240), "LOAD_SCHED" VARCHAR(100))
+RETURNS VARCHAR(16777216)
+LANGUAGE SQL
+EXECUTE AS OWNER
+AS '
+DECLARE var_job VARCHAR(255) default '''';            -- assigned task name derived from procedure name
+        var_proc VARCHAR(255)default '''';            -- task stored procedure name
+        var_dep VARCHAR(255) default '''';            -- task dependency name
+        var_seq INT default 0;                        -- load group sequence number
+        dep_arr ARRAY default ARRAY_CONSTRUCT();      -- array for dependencies
+        dep_counter INTEGER default 0;                -- dependency counter
+        dep_list VARCHAR(10000) default '''';         -- dependency list for AFTER clause in CREATE TASK statement
+        dep_last_task VARCHAR(255) default '''';      -- last dependency (needed to pass load cycle id to last task in dag)
+        proc_schema VARCHAR(255) default '''';        -- schema containing load procedures
+        task_name VARCHAR(255) default '''';          -- name of the task in the TASK CREATE statement
+        task_sql VARCHAR(10000) default '''';         -- single create task sql statement
+        var_sql VARCHAR(150000) default '''';         -- string containing sql statement to be executed
+        max_layer INT default 0;                      -- Number of load layers in FMC workflow
+        task_counter INT default 0;                   -- counter tallying # of tasks
+        
+BEGIN
+    -- Create initial task for getting load cycle id
+    var_sql := ''CREATE OR REPLACE TASK EXEC_''||UPPER(dag_name)||'' WAREHOUSE = ''||var_wh||'' SCHEDULE = ''''''||load_sched||'''''' AS CALL ''||UPPER(task_schema)||''.GET_LOAD_CYCLE_ID();'';
+    EXECUTE IMMEDIATE var_sql;
+    task_counter := task_counter + 1;
+
+    -- Create temp table for task mappings (jobs)
+    CREATE OR REPLACE TEMP TABLE JOBS (SEQ INT, JOB VARCHAR(50), PROC_SCHEMA VARCHAR(50), DEPENDENCY VARCHAR(50));
+
+    -- Insert task mappings into JSON temp table, assigning a number sequence to each load layer.
+    INSERT INTO JOBS (SEQ, JOB, PROC_SCHEMA, DEPENDENCY)
+    WITH JD AS (
+    SELECT j.KEY AS JOB
+        ,j.VALUE:map_schema::string AS PROC_SCHEMA
+        ,d.VALUE::string AS DEPENDENCY
+    FROM TASK_MAPPING,
+        LATERAL FLATTEN(input=> JSON_MAPPING) j, 
+        LATERAL FLATTEN(input=> j.VALUE:dependencies, outer=> true) d
+    )
+    ,"00" AS (
+        SELECT 0 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY is null
+     )
+    ,"01" AS (
+        SELECT 1 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "00")
+    )
+    ,"02" AS (
+        SELECT 2 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "01")
+    )
+    ,"03" AS (
+        SELECT 3 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "02")
+    )
+    ,"04" AS (
+        SELECT 4 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "03")
+    )
+    ,"05" AS (
+        SELECT 5 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "04")
+    )
+    ,"06" AS (
+        SELECT 6 AS SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM JD WHERE DEPENDENCY IN (SELECT JOB FROM "05")
+    )
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "00"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "01"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "02"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "03"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "04"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "05"
+    UNION ALL
+    SELECT SEQ, JOB, PROC_SCHEMA, DEPENDENCY FROM "06";
+
+    -- Get the number of load layers
+    SELECT MAX(SEQ) INTO max_layer FROM JOBS;
+    
+    -- Create task for logging start of FMC
+    SELECT JOB INTO var_job FROM JOBS WHERE SEQ = 0;
+    SELECT PROC_SCHEMA INTO proc_schema FROM JOBS WHERE SEQ = 0;
+    var_sql := ''CREATE OR REPLACE TASK EXEC_''||UPPER(var_job)||'' WAREHOUSE = ''||var_wh||'' AFTER EXEC_''||UPPER(dag_name)||'' AS 
+    BEGIN
+        CALL ''||UPPER(proc_schema)||''.''||UPPER(var_job)||''(''''''||dag_name||'''''', TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE()), TO_VARCHAR(CURRENT_TIMESTAMP::timestamp));
+        CALL SYSTEM$SET_RETURN_VALUE(SYSTEM$GET_PREDECESSOR_RETURN_VALUE());
+    END;'';
+    EXECUTE IMMEDIATE var_sql;
+    task_counter := task_counter + 1;
+
+    -- Create load tasks in order of dependency for all mappings after the initial mapping (>0). 
+    -- The MAX() on SEQ is applied to insure procedures that span multiple layers run after all its dependent tasks have been created.
+    DECLARE j1 cursor for SELECT JOB, PROC_SCHEMA, MAX(SEQ) AS SEQ FROM JOBS WHERE SEQ > 0 GROUP BY JOB, PROC_SCHEMA ORDER BY SEQ;
+    BEGIN
+        FOR record in j1 do
+            var_proc := record.JOB;
+            proc_schema := record.PROC_SCHEMA;
+            var_seq := record.SEQ;
+            
+            -- set task name; if it is last task in the dag add the dag name to the end logging procedure
+            task_name := CASE WHEN :var_seq = :max_layer THEN 
+                                    ''EXEC_''||UPPER(var_proc)||''_''||dag_name
+                                ELSE 
+                                    ''EXEC_''||UPPER(var_proc)
+                                END;
+            
+            task_sql := ''CREATE OR REPLACE TASK ''||task_name||'' WAREHOUSE = ''||var_wh||'' AFTER '';
+
+            -- Build dependency list; 
+            SELECT ARRAY_AGG(TO_ARRAY(DEPENDENCY)) INTO dep_arr FROM JOBS WHERE JOB = :var_proc; 
+            dep_list := '''';
+            dep_counter := 0;
+            FOR dep in dep_arr DO
+                dep_counter := dep_counter + 1;
+                dep_list := dep_list||CASE WHEN :dep_counter > 1 THEN '', '' ELSE '''' END||''EXEC_''||UPPER(ARRAY_TO_STRING(dep,'', ''));
+                --Get the last dependency, ensuring only one dependency task is called to fetch the load cycle id.
+                dep_last_task := ''EXEC_''||UPPER(ARRAY_TO_STRING(dep,'', ''));
+            END FOR;
+
+            -- Build create task statements; the last layer is run without the handling procedure.
+            var_sql := CASE WHEN :var_seq = :max_layer THEN  -- last task in DAG; SUCCESS
+                                task_sql||dep_list||'' AS CALL ''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''(TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||'''''')), ''''1'''');''
+                            ELSE -- all other tasks, run within handling procedure
+                                task_sql||dep_list||'' AS BEGIN 
+                                                            CALL ''||UPPER(task_schema)||''.RUN_MAPPING_PROC(''''''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''()'''', TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||''''''))); 
+                                                            CALL SYSTEM$SET_RETURN_VALUE(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||'''''')); 
+                                                          END;''
+                            END;
+            EXECUTE IMMEDIATE var_sql;
+            task_counter := task_counter + 1;
+        END FOR;
+    END;
+
+    DROP TABLE JOBS;
+
+    -- Enable all tasks in the dag
+    SELECT SYSTEM$TASK_DEPENDENTS_ENABLE(''EXEC_''||:dag_name);
+
+    RETURN TO_VARCHAR(task_counter)||'' tasks created for dag ''''''||''EXEC_''||:dag_name||''''''.'';
+
+END;
+';

--- a/snowflake_tasks/snowsql_deploy.sh
+++ b/snowflake_tasks/snowsql_deploy.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+##################################################
+## Variables - change these for you environment ##
+##################################################
+
+snowsql_conn=bryan
+snowflake_warehouse=VAULTSPEED
+task_schema=TASKER
+default_schedule="USING CRON 0 0 1 1 * America/New_York" ## Here, 01 January at midnight is the default when no schedule is available in the FMC definition
+agent_folder=/home/vsstudent/agent
+zipname=$1
+
+## Set file and directory paths
+path_to_generated_files=`cat $agent_folder/client.properties | grep ^path.in | cut -d '=' -f 2`
+# Check if the zipfile is there
+if ! [ -f $path_to_generated_files/$zipname ]; then
+    echo "cannot find file $path_to_generated_files/$zipname"
+    echo "exiting script"
+    exit 0
+fi
+
+## Get basename of zipfile (= remove everything after the first '.'), this will be used as the foldername to unzip the files in
+dirname=$path_to_generated_files/${zipname%%.*}
+
+## determine name of logfile
+## logfile=$dirname"_deploy.log"
+## echo "name of logfile: $logfile"
+
+unzip -q -u $path_to_generated_files/$zipname -d $dirname
+
+## Clean up the mapping file--remove backslash escape
+fmc_json_mapping=$(cat $path_to_generated_files/${zipname%%.*}/*mappings*.json)
+bkslshstr='\\"'
+fmc_json_mapping=${fmc_json_mapping//$bkslshstr/}
+
+## Truncate table that stores JSON mapping
+snowsql -c $snowsql_conn -o exit_on_error=true -q "TRUNCATE TASKER.TASK_MAPPING;"
+
+## Insert JSON mapping into task mapping table; use as work table for task generation procedure
+snowsql -c $snowsql_conn -o exit_on_error=true -q "INSERT INTO TASKER.TASK_MAPPING (JSON_MAPPING) SELECT TO_VARIANT(PARSE_JSON('$fmc_json_mapping'));"
+
+## Remove VaultSpeed ASCII header from info JSON
+fmc_json_text=$(cat $path_to_generated_files/${zipname%%.*}/*FMC_info*.json)
+dv_find_str='"dv_code"':
+pos=$(awk -v a="$fmc_json_text" -v b="$dv_find_str" 'BEGIN{print index(a,b)}')
+fmc_json_text={"${fmc_json_text:$pos+33}"
+
+## Get DAG name and scheduling parameters from info JSON
+dag_name=$(echo $fmc_json_text|jq -r '.dag_name')
+schedule_interval=$(echo $fmc_json_text|jq -r '.schedule_interval')
+
+##Add a default schedule if no value is available in schedule_interval (required for Snowflake Tasks)
+if [ "$schedule_interval" == "" ] 
+then
+    schedule_interval=$default_schedule
+fi
+
+## Execute procedure to generate tasks/dag
+snowsql -c $snowsql_conn -o exit_on_error=true -q "CALL TASKER.CREATE_VS_FMC('$snowflake_warehouse', '$task_schema', '$dag_name', '$schedule_interval');"
+
+
+exit 0


### PR DESCRIPTION
The code package provides the Snowflake SQL objects and bash script for automatically deploying and running VaultSpeed FMC workflow as task dags in Snowflake. It DOES NTO support Object-specific loading, yet.