### PR TITLE
updates to match the changes introduced by VaultSpeed version 7.0

### DIFF
--- a/dbt_cloud/macros/fmc_upd_run_status_fl.sql
+++ b/dbt_cloud/macros/fmc_upd_run_status_fl.sql
@@ -1,9 +1,7 @@
 {% macro fmc_upd_run_status_fl(dag_name, proc_schema, proc_name, success_flag) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
         call "{{ proc_schema }}"."{{proc_name}}"(
-            (select lci from {{lci_table}}),
             '{{success_flag}}'
         );
         commit;
@@ -14,11 +12,9 @@
 {% endmacro %}
 
 {% macro fmc_upd_run_status_fl_object_based(dag_name, proc_schema, proc_name, success_flag) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
         call "{{ proc_schema }}"."{{proc_name}}"(
-            (select lci from {{lci_table}}),
             '{{success_flag}}',
             'Y'
         );

--- a/dbt_cloud/macros/set_fmc_mtd_bv_incr.sql
+++ b/dbt_cloud/macros/set_fmc_mtd_bv_incr.sql
@@ -1,12 +1,9 @@
 {% macro set_fmc_mtd_bv_incr(dv_name, dag_name, proc_schema, proc_name) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
-        drop table if exists {{lci_table}};
-        create table {{lci_table}} as select {{dv_name}}_load_cycle_seq.nextval as lci;
         call "{{ proc_schema }}"."{{proc_name}}"(
             '{{ dag_name }}',
-            (select lci from {{lci_table}}),
+            {{dv_name}}_load_cycle_seq.nextval,
             TO_VARCHAR(TO_TIMESTAMP_NTZ(current_timestamp))
         );
         commit;

--- a/dbt_cloud/macros/set_fmc_mtd_bv_init.sql
+++ b/dbt_cloud/macros/set_fmc_mtd_bv_init.sql
@@ -1,12 +1,9 @@
 {% macro set_fmc_mtd_bv_init(dv_name, dag_name, proc_schema, proc_name, start_date) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
-        drop table if exists {{lci_table}};
-        create table {{lci_table}} as select {{dv_name}}_load_cycle_seq.nextval as lci;
         call "{{ proc_schema }}"."{{proc_name}}"(
             '{{ dag_name }}',
-            (select lci from {{lci_table}}),
+            {{dv_name}}_load_cycle_seq.nextval,
             '{{ start_date }}'
         );
         commit;

--- a/dbt_cloud/macros/set_fmc_mtd_fl_incr.sql
+++ b/dbt_cloud/macros/set_fmc_mtd_fl_incr.sql
@@ -1,12 +1,9 @@
 {% macro set_fmc_mtd_fl_incr(dv_name, dag_name, proc_schema, proc_name) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
-        drop table if exists {{lci_table}};
-        create table {{lci_table}} as select {{dv_name}}_load_cycle_seq.nextval as lci;
         call "{{ proc_schema }}"."{{proc_name}}"(
             '{{ dag_name }}',
-            (select lci from {{lci_table}}),
+            {{dv_name}}_load_cycle_seq.nextval,
             TO_VARCHAR(TO_TIMESTAMP_NTZ(current_timestamp))
         );
         commit;

--- a/dbt_cloud/macros/set_fmc_mtd_fl_init.sql
+++ b/dbt_cloud/macros/set_fmc_mtd_fl_init.sql
@@ -1,12 +1,9 @@
 {% macro set_fmc_mtd_fl_init(dv_name, dag_name, proc_schema, proc_name, start_date) -%}
-    {%- set lci_table = dag_name + '_lci' -%}
     {% set query -%}
         begin transaction;
-        drop table if exists {{lci_table}};
-        create table {{lci_table}} as select {{dv_name}}_load_cycle_seq.nextval as lci;
         call "{{ proc_schema }}"."{{proc_name}}"(
             '{{ dag_name }}',
-            (select lci from {{lci_table}}),
+            {{dv_name}}_load_cycle_seq.nextval,
             '{{ start_date }}'
         );
         commit;

--- a/snowflake_tasks/SF_DAG_DEPLOY_OBJECTS.sql
+++ b/snowflake_tasks/SF_DAG_DEPLOY_OBJECTS.sql
@@ -29,7 +29,7 @@ AS '
 ';
 
 -- 5. Create wrapper stored procedure for running procedures and logging failure if procedure fails
-CREATE OR REPLACE PROCEDURE TASKER.RUN_MAPPING_PROC("PROC_NAME" VARCHAR(255), "LOAD_CYCLE_ID" VARCHAR(16777216))
+CREATE OR REPLACE PROCEDURE TASKER.RUN_MAPPING_PROC("PROC_NAME" VARCHAR(255))
 
 RETURNS VARCHAR(16777216)
 LANGUAGE JAVASCRIPT
@@ -132,7 +132,6 @@ BEGIN
     var_sql := ''CREATE OR REPLACE TASK EXEC_''||UPPER(var_job)||'' WAREHOUSE = ''||var_wh||'' AFTER EXEC_''||UPPER(dag_name)||'' AS 
     BEGIN
         CALL ''||UPPER(proc_schema)||''.''||UPPER(var_job)||''(''''''||dag_name||'''''', TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE()), TO_VARCHAR(CURRENT_TIMESTAMP::timestamp));
-        CALL SYSTEM$SET_RETURN_VALUE(SYSTEM$GET_PREDECESSOR_RETURN_VALUE());
     END;'';
     EXECUTE IMMEDIATE var_sql;
     task_counter := task_counter + 1;
@@ -162,17 +161,14 @@ BEGIN
             FOR dep in dep_arr DO
                 dep_counter := dep_counter + 1;
                 dep_list := dep_list||CASE WHEN :dep_counter > 1 THEN '', '' ELSE '''' END||''EXEC_''||UPPER(ARRAY_TO_STRING(dep,'', ''));
-                --Get the last dependency, ensuring only one dependency task is called to fetch the load cycle id.
-                dep_last_task := ''EXEC_''||UPPER(ARRAY_TO_STRING(dep,'', ''));
             END FOR;
 
             -- Build create task statements; the last layer is run without the handling procedure.
             var_sql := CASE WHEN :var_seq = :max_layer THEN  -- last task in DAG; SUCCESS
-                                task_sql||dep_list||'' AS CALL ''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''(TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||'''''')), ''''1'''');''
+                                task_sql||dep_list||'' AS CALL ''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''(''''1'''');''
                             ELSE -- all other tasks, run within handling procedure
                                 task_sql||dep_list||'' AS BEGIN 
-                                                            CALL ''||UPPER(task_schema)||''.RUN_MAPPING_PROC(''''''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''()'''', TO_VARCHAR(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||''''''))); 
-                                                            CALL SYSTEM$SET_RETURN_VALUE(SYSTEM$GET_PREDECESSOR_RETURN_VALUE(''''''||dep_last_task||'''''')); 
+                                                            CALL ''||UPPER(task_schema)||''.RUN_MAPPING_PROC(''''''||UPPER(proc_schema)||''.''||UPPER(var_proc)||''()'''');
                                                           END;''
                             END;
             EXECUTE IMMEDIATE var_sql;


### PR DESCRIPTION
remove the load cycle id input from a lot of the FMC procedures.